### PR TITLE
Update to support newest Obfuscar version

### DIFF
--- a/MSBuild.Obfuscar.Test/MSBuild.Obfuscar.Test.csproj
+++ b/MSBuild.Obfuscar.Test/MSBuild.Obfuscar.Test.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Obfuscar.2.2.11\build\obfuscar.props" Condition="Exists('..\packages\Obfuscar.2.2.11\build\obfuscar.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -54,6 +55,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\MSBuild.Obfuscar\build\MSBuild.Obfuscar.targets" Condition="Exists('..\MSBuild.Obfuscar\build\MSBuild.Obfuscar.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Obfuscar.2.2.11\build\obfuscar.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Obfuscar.2.2.11\build\obfuscar.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MSBuild.Obfuscar.Test/packages.config
+++ b/MSBuild.Obfuscar.Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Obfuscar" version="2.2.10" targetFramework="net40" developmentDependency="true" />
+  <package id="Obfuscar" version="2.2.11" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/MSBuild.Obfuscar/Package.nuspec
+++ b/MSBuild.Obfuscar/Package.nuspec
@@ -14,13 +14,13 @@
     <description>Build targets interface of Obfuscar</description>
     <summary>$description$</summary>
     <releaseNotes>
-      Includes 'Obfuscar' v2.2.10 in a solution-level NuGet package
+      Includes 'Obfuscar' v2.2.11 in a solution-level NuGet package
     </releaseNotes>
     <copyright>$copyright$</copyright>
     <language>en</language>
     <tags>Obfuscar MSBuild Targets</tags>
     <dependencies>
-      <dependency id="Obfuscar" version="2.2.10" />
+      <dependency id="Obfuscar" version="2.2.11" />
     </dependencies>
   </metadata>
   <files>

--- a/MSBuild.Obfuscar/Properties/AssemblyInfo.cs
+++ b/MSBuild.Obfuscar/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Resources;
 [assembly: AssemblyProduct("MSBuild.Obfuscar")]
 [assembly: AssemblyCopyright("Copyright (C) LeXtudio 2015")]
 
-[assembly: AssemblyVersion("2.2.10.*")]
-[assembly: AssemblyFileVersion("2.2.10.0")]
+[assembly: AssemblyVersion("2.2.11.*")]
+[assembly: AssemblyFileVersion("2.2.11.0")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/MSBuild.Obfuscar/build/MSBuild.Obfuscar.targets
+++ b/MSBuild.Obfuscar/build/MSBuild.Obfuscar.targets
@@ -14,8 +14,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup>
 
     <!-- ObfuscatorToolsPath -->
-    <ObfuscatorToolsPath>$(MSBuildThisFileDirectory)..\..\Obfuscar.2.2.10\tools</ObfuscatorToolsPath>
-    <ObfuscatorToolsPath Condition="!Exists('$(ObfuscatorToolsPath)')">$(SolutionDir)packages\Obfuscar.2.2.10\tools</ObfuscatorToolsPath>
+    <ObfuscatorToolsPath>$(MSBuildThisFileDirectory)..\..\Obfuscar.2.2.11\tools</ObfuscatorToolsPath>
+    <ObfuscatorToolsPath Condition="!Exists('$(ObfuscatorToolsPath)')">$(SolutionDir)packages\Obfuscar.2.2.11\tools</ObfuscatorToolsPath>
 
   </PropertyGroup>
 


### PR DESCRIPTION
This commit updates some version numbers, so that the msbuild target works with the latest Obfuscar version (2.2.11).

Assembly information and test dependencies have also been adjusted.